### PR TITLE
feat(userjs/chatgpt): new default domain for ChatGPT

### DIFF
--- a/userjs/chatgpt/replace_send_key.user.js
+++ b/userjs/chatgpt/replace_send_key.user.js
@@ -1,10 +1,11 @@
 // ==UserScript==
 // @name         替换发送快捷键
 // @namespace    http://tampermonkey.net/
-// @version      1.0
+// @version      1.1
 // @description  替换enter为换行，enter+shift为发送
 // @author       YigeYigeren
 // @match        https://chat.openai.com/*
+// @match        https://chatgpt.com/*
 // @supportURL   https://github.com/yige-yigeren/YigerenUserScript/issues
 // @homepageURL  https://github.com/yige-yigeren/YigerenUserScript
 // @downloadURL  https://github.com/yige-yigeren/YigerenUserScript/raw/main/userjs/chatgpt/replace_send_key.user.js

--- a/userjs/chatgpt/replace_send_key.user.js
+++ b/userjs/chatgpt/replace_send_key.user.js
@@ -3,7 +3,7 @@
 // @namespace    http://tampermonkey.net/
 // @version      1.1
 // @description  替换enter为换行，enter+shift为发送
-// @author       YigeYigeren
+// @author       YigeYigeren & ChrAlpha
 // @match        https://chat.openai.com/*
 // @match        https://chatgpt.com/*
 // @supportURL   https://github.com/yige-yigeren/YigerenUserScript/issues


### PR DESCRIPTION
OpenAI recently redirected the default domain of ChatGPT from `chat.openai.com` to `chatgpt.com`.